### PR TITLE
tcrun: tweak the output for `tcrun -toolchains`

### DIFF
--- a/Sources/tcrun/SwiftInstallation.swift
+++ b/Sources/tcrun/SwiftInstallation.swift
@@ -122,7 +122,6 @@ extension SwiftInstallation {
   }
 }
 
-#if DEBUG
 extension SwiftInstallation: CustomStringConvertible {
   public var description: String {
     return """
@@ -133,7 +132,7 @@ extension SwiftInstallation: CustomStringConvertible {
       Toolchains:
       \(
         toolchains.map {
-          "  - \($0.location.path) [\($0.identifier)]"
+          "  - \($0.identifier) [\($0.location.path)]"
         }.joined(separator: "\n    ")
       )
       Platforms:
@@ -154,4 +153,3 @@ extension SwiftInstallation: CustomStringConvertible {
     """
   }
 }
-#endif


### PR DESCRIPTION
Use the identifier as the primary key and the path as the auxiliary information in the rendering. This matches the toolchain output with the SDK enumeration and highlights the information that the user is more likely after - the toolchain identifier for `-toolchain` or `TOOLCHAINS`.