### PR TITLE
Extensions: mark `SubKeyIterator` as `final`

### DIFF
--- a/Sources/tcrun/Extensions/WinSDK+ManagedHandle.swift
+++ b/Sources/tcrun/Extensions/WinSDK+ManagedHandle.swift
@@ -60,7 +60,7 @@ extension ManagedHandle where Value == HKEY {
 }
 
 extension ManagedHandle where Value == HKEY {
-  internal class SubKeyIterator: IteratorProtocol, Sequence {
+  internal final class SubKeyIterator: IteratorProtocol, Sequence {
     public typealias Element = String
 
     private var key: ManagedHandle<HKEY>


### PR DESCRIPTION
The need for the `class` here is to get reference semantics to allow mutation and to make the `subkeys` accessor throwing. Mark the type as `final`.