### PR TITLE
tcrun: structure tuples for readability

### DIFF
--- a/Sources/tcrun/Platform.swift
+++ b/Sources/tcrun/Platform.swift
@@ -1,0 +1,36 @@
+// Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import Foundation
+
+internal struct Platform {
+  public let id: String
+  public let SDKs: [URL]
+
+  public init(id: String, SDKs: [URL]) {
+    self.id = id
+    self.SDKs = SDKs
+  }
+
+  public func contains(sdk named: String) -> Bool {
+    SDKs.contains { $0.lastPathComponent == named }
+  }
+
+  public func sdk(named name: String) -> URL? {
+    SDKs.first { $0.lastPathComponent == name }
+  }
+}
+
+internal struct PlatformCollection {
+  public let root: URL
+  public let platforms: [Platform]
+
+  public init(root: URL, platforms: [Platform]) {
+    self.root = root
+    self.platforms = platforms
+  }
+
+  public func containing(sdk: String) -> [Platform] {
+    platforms.filter { $0.contains(sdk: sdk) }
+  }
+}

--- a/Sources/tcrun/Toolchain.swift
+++ b/Sources/tcrun/Toolchain.swift
@@ -1,0 +1,18 @@
+// Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import Foundation
+
+internal struct Toolchain {
+  public let identifier: String
+  public let location: URL
+
+  public init(identifier: String, location: URL) {
+    self.identifier = identifier
+    self.location = location
+  }
+
+  public var bindir: URL {
+    location.appending(components: "usr", "bin", directoryHint: .isDirectory)
+  }
+}

--- a/Sources/tcrun/main.swift
+++ b/Sources/tcrun/main.swift
@@ -27,7 +27,7 @@ extension Array where Element == SwiftInstallation {
 
 extension SwiftInstallation {
   fileprivate func platforms(containing sdk: String)
-      -> [(id: String, SDKs: [URL])] {
+      -> [Platform] {
     self.platforms.platforms.filter {
       $0.SDKs.filter { $0.lastPathComponent == sdk }.count > 0
     }
@@ -130,7 +130,7 @@ private struct tcrun: ParsableCommand {
         installations.select(toolchain: OPT_toolchain, sdk: OPT_sdk)
     guard let installation else { return }
 
-    guard let platform: (id: String, SDKs: [URL]) =
+    guard let platform: Platform =
         installation.platforms(containing: OPT_sdk).first else { return }
 
     if showSDKPlatformPath {
@@ -149,7 +149,7 @@ private struct tcrun: ParsableCommand {
       return print(sdk.path)
     }
 
-    let toolchain: (identifier: String, location: URL)? =
+    let toolchain: Toolchain? =
         installation.toolchains.first(where: {
           OPT_toolchain == nil ? true : $0.identifier == OPT_toolchain
         })


### PR DESCRIPTION
This replaces the complex tuple types for structures to improve clarity and readability in the codebase.