### PR TITLE
tcrun: make `PlatformCollection` conform to `Collection`

### DIFF
--- a/Sources/tcrun/Platform.swift
+++ b/Sources/tcrun/Platform.swift
@@ -34,3 +34,24 @@ internal struct PlatformCollection {
     platforms.filter { $0.contains(sdk: sdk) }
   }
 }
+
+extension PlatformCollection: Collection {
+  public typealias Element = Platform
+  public typealias Index = Array<Platform>.Index
+
+  public var startIndex: Index {
+    platforms.startIndex
+  }
+
+  public var endIndex: Index {
+    platforms.endIndex
+  }
+
+  public subscript(index: Index) -> Platform {
+    return platforms[index]
+  }
+
+  public func index(after i: Index) -> Index {
+    return platforms.index(after: i)
+  }
+}

--- a/Sources/tcrun/SwiftInstallation.swift
+++ b/Sources/tcrun/SwiftInstallation.swift
@@ -138,7 +138,7 @@ extension SwiftInstallation: CustomStringConvertible {
       )
       Platforms:
       \(
-        platforms.platforms.map {
+        platforms.map {
           """
             - \($0.id)
                   SDKs:


### PR DESCRIPTION
Conformance to `Collection` allows treating the collection as a collection allowing cleaner and more idiomatic usage in the rest of the codebase.