### PR TITLE
tcrun: sink and reorganise some code

### DIFF
--- a/Sources/tcrun/SwiftInstallation.swift
+++ b/Sources/tcrun/SwiftInstallation.swift
@@ -165,3 +165,21 @@ extension SwiftInstallation: CustomStringConvertible {
     """
   }
 }
+
+extension Array where Element == SwiftInstallation {
+  internal func select(toolchain: String?, sdk: String?) -> SwiftInstallation? {
+    return first { installation in
+      let toolchain = toolchain.map { id in
+        installation.toolchains.contains { $0.identifier == id }
+      } ?? true
+
+      let sdk = sdk.map { name in
+        installation.platforms.contains { platform in
+          platform.SDKs.contains { $0.lastPathComponent == name }
+        }
+      } ?? true
+
+      return toolchain && sdk
+    }
+  }
+}


### PR DESCRIPTION
This pull request refactors and reorganizes utility methods related to toolchain and platform selection in the `tcrun` tool. The main changes move several helper extensions and methods from `main.swift` into their more appropriate types, improving code organization and encapsulation. The logic for selecting toolchains and platforms, as well as tool execution, remains unchanged.

### Refactoring and Code Organization

* Moved the `select(toolchain:sdk:)` extension for `[SwiftInstallation]`, and the `platforms(containing:)` and `platform(containing:)` methods for `SwiftInstallation`, from `main.swift` into `SwiftInstallation.swift` to better encapsulate platform and toolchain selection logic. [[1]](diffhunk://#diff-fb231fd089e5056521adbc0fba4eb45e1aac8c41da4978c8a4548e163811d1b1L9-L80) [[2]](diffhunk://#diff-d6f2d1eba6810aeaf9aea4df37f132c98949199523ae2e0a45f13b6556da1022R125-R136) [[3]](diffhunk://#diff-d6f2d1eba6810aeaf9aea4df37f132c98949199523ae2e0a45f13b6556da1022R168-R185)
* Moved the `find(_:)` and `execute(_:sdk:arguments:)` methods for `Toolchain` from `main.swift` into `Toolchain.swift`, making tool execution logic local to the `Toolchain` type. [[1]](diffhunk://#diff-fb231fd089e5056521adbc0fba4eb45e1aac8c41da4978c8a4548e163811d1b1L9-L80) [[2]](diffhunk://#diff-347143c9d9f20ebb69f8a62ecf17da2e272d5ca7a29d5c85663cfbc82ca1d735R19-R40)

### Simplification of Main Command Logic

* Removed the `ToolchainResolver` struct and updated the main command to use the new `[SwiftInstallation].select(toolchain:sdk:)` extension directly, simplifying the toolchain selection flow. [[1]](diffhunk://#diff-fb231fd089e5056521adbc0fba4eb45e1aac8c41da4978c8a4548e163811d1b1L9-L80) [[2]](diffhunk://#diff-fb231fd089e5056521adbc0fba4eb45e1aac8c41da4978c8a4548e163811d1b1L166-R101)
* Minor code cleanup in the `.run` command case to clarify tool URL construction before execution.

### Minor Formatting

* Fixed formatting of the `EnumerateToolchains` function signature for consistency.