### PR TITLE
SwiftInstallation: uopt the registry scanning

### DIFF
--- a/Sources/tcrun/SwiftInstallation.swift
+++ b/Sources/tcrun/SwiftInstallation.swift
@@ -64,12 +64,7 @@ extension SwiftInstallation {
       throws -> SwiftInstallation? {
     let hSubKey = try hKey.OpenKey(lpSubKey, 0, KEY_READ)
 
-    guard let szDisplayName =
-            try? hSubKey.QueryValue(nil, "DisplayName"),
-        let szDisplayVersion =
-            try? hSubKey.QueryValue(nil, "DisplayVersion"),
-        let szPublisher =
-            try? hSubKey.QueryValue(nil, "Publisher") else {
+    guard let szDisplayName = try? hSubKey.QueryValue(nil, "DisplayName") else {
       return nil
     }
 
@@ -77,8 +72,13 @@ extension SwiftInstallation {
       return nil
     }
 
-    guard let szInstallPath =
-        try? hSubKey.QueryValue("Variables", "InstallRoot") else {
+    guard let szDisplayVersion = try? hSubKey.QueryValue(nil, "DisplayVersion"),
+        let szPublisher = try? hSubKey.QueryValue(nil, "Publisher") else {
+      return nil
+    }
+
+    let hVariables = try hSubKey.OpenKey("Variables", 0, KEY_READ)
+    guard let szInstallPath = try? hVariables.QueryValue(nil, "InstallRoot") else {
       return nil
     }
 


### PR DESCRIPTION
Ensure that we are looking at a Swift installation before querying all the other subkeys. Open the subkey directly to enable future simplification of `QueryValue` (removing the `lpSubKey` parameter).