### PR TITLE
tcrun: explicitly annotate access level (NFC)

### DIFF
--- a/Sources/tcrun/Support/Version.swift
+++ b/Sources/tcrun/Support/Version.swift
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 internal struct Version {
-  let major: Int
-  let minor: Int
-  let patch: Int
+  public let major: Int
+  public let minor: Int
+  public let patch: Int
 
-  init(major: Int, minor: Int, patch: Int) {
+  public init(major: Int, minor: Int, patch: Int) {
     self.major = major
     self.minor = minor
     self.patch = patch
   }
 
-  init?(_ version: String) {
+  public init?(_ version: String) {
     let components = version.split(separator: "-")[0].split(separator: ".").compactMap { Int($0) }
     guard components.count == 3 else {
       return nil
@@ -24,7 +24,7 @@ internal struct Version {
 }
 
 extension Version: CustomStringConvertible {
-  var description: String {
+  public var description: String {
     "\(major).\(minor).\(patch)"
   }
 }

--- a/Sources/tcrun/main.swift
+++ b/Sources/tcrun/main.swift
@@ -8,11 +8,11 @@ internal import Foundation
 
 @main
 private struct tcrun: ParsableCommand {
-  static var configuration: CommandConfiguration {
+  public static var configuration: CommandConfiguration {
     CommandConfiguration(abstract: "Swift Toolchain Execution Helper")
   }
 
-  enum Mode: EnumerableFlag {
+  public enum Mode: EnumerableFlag {
     case find
     case run
 
@@ -37,40 +37,40 @@ private struct tcrun: ParsableCommand {
 
   @Flag(name: [.customLong("version", withSingleDash: true), .long],
         help: "Print the version of the tool")
-  var version: Bool = false
+  public var version: Bool = false
 
   @Flag(name: [.customLong("show-sdk-path", withSingleDash: true), .long],
         help: "Print the path to the SDK")
-  var showSDKPath: Bool = false
+  public var showSDKPath: Bool = false
 
   @Flag(name: [.customLong("show-sdk-platform-path", withSingleDash: true),
                .long],
         help: "Print the path to the SDK platform")
-  var showSDKPlatformPath: Bool = false
+  public var showSDKPlatformPath: Bool = false
 
   // FIXME: should this be moved into a `toolchain-select` tool?
   @Flag(name: [.customLong("toolchains", withSingleDash: true), .long],
         help: "List the available toolchains")
-  var toolchains: Bool = false
+  public var toolchains: Bool = false
 
   @Option(name: .customLong("sdk", withSingleDash: true),
           help: "Use the specified SDK")
-  var sdk: String?
+  public var sdk: String?
 
   @Option(name: .customLong("toolchain", withSingleDash: true),
           help: "Use the specified toolchain")
-  var toolchain: String?
+  public var toolchain: String?
 
   @Flag()
-  var mode: Mode = .run
+  public var mode: Mode = .run
 
   @Argument
-  var tool: String = ""
+  public var tool: String = ""
 
   @Argument(parsing: .remaining)
-  var arguments: [String] = []
+  public var arguments: [String] = []
 
-  func validate() throws {
+  public func validate() throws {
     guard !version else { return }
 
     guard !showSDKPath, !showSDKPlatformPath else { return }
@@ -81,7 +81,7 @@ private struct tcrun: ParsableCommand {
     }
   }
 
-  mutating func run() throws {
+  public mutating func run() throws {
     guard !version else { return print("tcrun \(version)") }
 
     let TOOLCHAINS = try GetEnvironmentVariable("TOOLCHAINS")


### PR DESCRIPTION
Explicitly mark the interface access level for clarity.