### PR TITLE
Support: improve `Version` handling

### DIFF
--- a/Sources/tcrun/Support/Version.swift
+++ b/Sources/tcrun/Support/Version.swift
@@ -13,13 +13,14 @@ internal struct Version {
   }
 
   public init?(_ version: String) {
-    let components = version.split(separator: "-")[0].split(separator: ".").compactMap { Int($0) }
-    guard components.count == 3 else {
+    guard let version = version.split(separator: "-", maxSplits: 1).first else {
       return nil
     }
-    self.major = components[0]
-    self.minor = components[1]
-    self.patch = components[2]
+
+    let components = version.split(separator: ".").compactMap { Int($0) }
+    guard components.count == 3 else { return nil }
+
+    (major, minor, patch) = (components[0], components[1], components[2])
   }
 }
 

--- a/Sources/tcrun/Support/Version.swift
+++ b/Sources/tcrun/Support/Version.swift
@@ -24,6 +24,14 @@ internal struct Version {
   }
 }
 
+extension Version: Comparable {
+  public static func < (_ lhs: Version, _ rhs: Version) -> Bool {
+    guard lhs.major == rhs.major else { return lhs.major < rhs.major }
+    guard lhs.minor == rhs.minor else { return lhs.minor < rhs.minor }
+    return lhs.patch < rhs.patch
+  }
+}
+
 extension Version: CustomStringConvertible {
   public var description: String {
     "\(major).\(minor).\(patch)"

--- a/Sources/tcrun/SwiftInstallation.swift
+++ b/Sources/tcrun/SwiftInstallation.swift
@@ -117,8 +117,7 @@ extension SwiftInstallation {
       })
     }
 
-    // TODO(compnerd): sort by version number
-    return installations
+    return installations.sorted { $0.version > $1.version }
   }
 }
 


### PR DESCRIPTION
This pull request improves version handling and sorting for Swift installations by updating the `Version` struct to better parse version strings and by enabling version-based sorting of installations. The main improvements are:

**Version parsing and comparison enhancements:**

* Refactored the `Version` struct initializer to more robustly parse version strings, handling cases with or without a hyphen and ensuring correct extraction of major, minor, and patch numbers.
* Added `Comparable` conformance to the `Version` struct, allowing versions to be compared using standard operators.

**Sorting improvements:**

* Updated the Swift installation discovery logic to sort installations by version in descending order, ensuring that newer versions are prioritized.