### PR TITLE
SwiftInstallation: add some convenience methods

### DIFF
--- a/Sources/tcrun/SwiftInstallation.swift
+++ b/Sources/tcrun/SwiftInstallation.swift
@@ -122,6 +122,26 @@ extension SwiftInstallation {
 }
 
 extension SwiftInstallation {
+  internal func contains(toolchain identifier: String) -> Bool {
+    return toolchains.contains { $0.identifier == identifier }
+  }
+
+  internal func contains(sdk identifier: String) -> Bool {
+    return platforms.contains { platform in
+      return platform.SDKs.contains { $0.lastPathComponent == identifier }
+    }
+  }
+}
+
+extension SwiftInstallation {
+  internal func toolchain(matching identifier: String? = nil) -> Toolchain? {
+    return toolchains.first { toolchain in
+      return identifier.map { toolchain.identifier == $0 } ?? true
+    }
+  }
+}
+
+extension SwiftInstallation {
   internal func platforms(containing sdk: String) -> [Platform] {
     return self.platforms.filter { platform in
       return platform.SDKs.contains { $0.lastPathComponent == sdk }
@@ -168,17 +188,8 @@ extension SwiftInstallation: CustomStringConvertible {
 extension Array where Element == SwiftInstallation {
   internal func select(toolchain: String?, sdk: String?) -> SwiftInstallation? {
     return first { installation in
-      let toolchain = toolchain.map { id in
-        installation.toolchains.contains { $0.identifier == id }
-      } ?? true
-
-      let sdk = sdk.map { name in
-        installation.platforms.contains { platform in
-          platform.SDKs.contains { $0.lastPathComponent == name }
-        }
-      } ?? true
-
-      return toolchain && sdk
+      (toolchain.map(installation.contains(toolchain:)) ?? true) &&
+      (sdk.map(installation.contains(sdk:)) ?? true)
     }
   }
 }

--- a/Sources/tcrun/SwiftInstallation.swift
+++ b/Sources/tcrun/SwiftInstallation.swift
@@ -123,8 +123,8 @@ extension SwiftInstallation {
 
 extension SwiftInstallation {
   internal func platforms(containing sdk: String) -> [Platform] {
-    self.platforms.platforms.filter {
-      $0.SDKs.filter { $0.lastPathComponent == sdk }.count > 0
+    return self.platforms.filter { platform in
+      return platform.SDKs.contains { $0.lastPathComponent == sdk }
     }
   }
 


### PR DESCRIPTION
This pull request refactors and enhances the `SwiftInstallation` class by introducing new helper methods for checking toolchain and SDK presence, as well as simplifying the selection logic for installations. The main improvements are focused on code readability, maintainability, and encapsulation.

### Helper methods for toolchain and SDK lookup

* Added `contains(toolchain:)` and `contains(sdk:)` methods to `SwiftInstallation` to encapsulate the logic for checking if a toolchain or SDK exists within an installation.
* Added `toolchain(matching:)` method to retrieve the first matching toolchain by identifier, supporting optional filtering.

### Refactoring and simplification

* Refactored the `platforms(containing:)` method to use a more concise and idiomatic approach for filtering platforms containing a specific SDK.
* Simplified the `Array<SwiftInstallation>.select(toolchain:sdk:)` method by leveraging the new helper methods, improving readability and reducing code duplication.