### PR TITLE
tcrun: clean up the execution

### DIFF
--- a/Sources/tcrun/SwiftInstallation.swift
+++ b/Sources/tcrun/SwiftInstallation.swift
@@ -186,7 +186,7 @@ extension SwiftInstallation: CustomStringConvertible {
 }
 
 extension Array where Element == SwiftInstallation {
-  internal func select(toolchain: String?, sdk: String?) -> SwiftInstallation? {
+  internal func matching(toolchain: String?, sdk: String?) -> SwiftInstallation? {
     return first { installation in
       (toolchain.map(installation.contains(toolchain:)) ?? true) &&
       (sdk.map(installation.contains(sdk:)) ?? true)

--- a/Sources/tcrun/main.swift
+++ b/Sources/tcrun/main.swift
@@ -86,18 +86,18 @@ private struct tcrun: ParsableCommand {
       return print("tcrun \(PackageVersion)")
     }
 
+    let installations = try SwiftInstallation.enumerate()
+
+    if toolchains {
+      return installations.forEach { print($0) }
+    }
+
     let TOOLCHAINS = try GetEnvironmentVariable("TOOLCHAINS")
     let SDKROOT = try GetEnvironmentVariable("SDKROOT")
 
     let OPT_sdk =
         sdk ?? URL(filePath: SDKROOT ?? "Windows.sdk").lastPathComponent
     let OPT_toolchain = toolchain ?? TOOLCHAINS
-
-    let installations = try SwiftInstallation.enumerate()
-
-    if toolchains {
-      return installations.forEach { print($0) }
-    }
 
     guard let installation =
         installations.select(toolchain: OPT_toolchain, sdk: OPT_sdk) else {


### PR DESCRIPTION
This pull request refactors the logic for selecting and matching Swift installations and toolchains in the `tcrun` command-line tool. The main changes focus on improving code clarity and separation of concerns by splitting and renaming methods, as well as updating how toolchains are matched.

Refactoring and code clarity improvements:

* Renamed the `Array<SwiftInstallation>.select(toolchain:sdk:)` method to `matching(toolchain:sdk:)` for clearer intent.
* Split the logic in the `run()` method of `tcrun` into two methods: a new `run(selecting:toolchain:sdk:)` for handling the selected installation, and a simplified `run()` that handles argument parsing and installation selection. [[1]](diffhunk://#diff-fb231fd089e5056521adbc0fba4eb45e1aac8c41da4978c8a4548e163811d1b1L84-R86) [[2]](diffhunk://#diff-fb231fd089e5056521adbc0fba4eb45e1aac8c41da4978c8a4548e163811d1b1R119-R145)
* Updated the call site to use the new `matching(toolchain:sdk:)` method instead of the old `select(toolchain:sdk:)`.
* Simplified platform and SDK selection logic by removing unnecessary variable indirection and improving guard statements.
* Replaced manual toolchain lookup with a call to `installation.toolchain(matching:)` for improved encapsulation.