### PR TITLE
Extensions: remove unnecessary `import`

### DIFF
--- a/Sources/tcrun/Extensions/String+Extensions.swift
+++ b/Sources/tcrun/Extensions/String+Extensions.swift
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 internal import Foundation
-internal import WinSDK
 
 extension Optional where Wrapped == String {
   internal func withUTF16CString<T>(_ body: (UnsafePointer<UTF16.CodeUnit>?) throws -> T)


### PR DESCRIPTION
Clean up the import to remove the `import WinSDK`. We now fully use the WindowsCore module for Windows SDK.