### PR TITLE
tcrun: correct tool invocation

### DIFF
--- a/Sources/tcrun/main.swift
+++ b/Sources/tcrun/main.swift
@@ -151,7 +151,7 @@ private struct tcrun: ParsableCommand {
 
       case .run:
         if let sdk = platform.sdk(named: sdk) {
-          let tool = URL(filePath: tool)
+          let tool = URL(filePath: path)
           try toolchain.execute(tool, sdk: sdk.path, arguments: arguments)
         }
       }


### PR DESCRIPTION
Use the path to invoke the tool, which is named `path`.