### PR TITLE
tcrun: adjust behaviour for `tcun -sdk ... -f`

### DIFF
--- a/Sources/tcrun/Toolchain.swift
+++ b/Sources/tcrun/Toolchain.swift
@@ -65,13 +65,18 @@ extension Toolchain {
     try SearchExecutable(tool, in: self.bindir.path)
   }
 
-  internal func execute(_ tool: URL, sdk: String, arguments: [String]? = nil) throws -> Never {
+  internal func execute(_ tool: URL, _ arguments: [String]? = nil,
+                        sdk: URL? = nil) throws -> Never {
     let process = Process()
     process.executableURL = tool
     process.arguments = arguments
 
     var environment = ProcessInfo.processInfo.environment
-    environment.updateValue(sdk, forKey: "SDKROOT")
+    if let sdk {
+      environment.updateValue(sdk.path, forKey: "SDKROOT")
+    } else {
+      environment.removeValue(forKey: "SDKROOT")
+    }
     environment.removeValue(forKey: "TOOLCHAINS")
 
     process.environment = environment

--- a/Sources/tcrun/main.swift
+++ b/Sources/tcrun/main.swift
@@ -141,6 +141,8 @@ private struct tcrun: ParsableCommand {
 
     // Handle tool execution.
     if let toolchain = installation.toolchain(matching: toolchain) {
+      // TODO(compnerd): if `-sdk` is specified, the tool search should be
+      // scoped to the SDK rather than the toolchain.
       guard let path = try toolchain.find(tool) else {
         return
       }
@@ -150,10 +152,8 @@ private struct tcrun: ParsableCommand {
         print(path)
 
       case .run:
-        if let sdk = platform.sdk(named: sdk) {
-          let tool = URL(filePath: path)
-          try toolchain.execute(tool, sdk: sdk.path, arguments: arguments)
-        }
+        try toolchain.execute(URL(filePath: path), arguments,
+                              sdk: self.sdk.map(platform.sdk(named:)) ?? nil)
       }
     }
   }


### PR DESCRIPTION
When `-sdk` is specified in the search mode, it restricts the search to the SDK rather than scoping it to the toolchain. Adjust the `toolchain.execute` to take an optional `sdk` which forms the `SDKROOT`.