### PR TITLE
tcrun: hoist `execute` out of `Toolchain`

### DIFF
--- a/Sources/tcrun/Toolchain.swift
+++ b/Sources/tcrun/Toolchain.swift
@@ -64,25 +64,4 @@ extension Toolchain {
   internal func find(_ tool: String) throws -> String? {
     try SearchExecutable(tool, in: self.bindir.path)
   }
-
-  internal func execute(_ tool: URL, _ arguments: [String]? = nil,
-                        sdk: URL? = nil) throws -> Never {
-    let process = Process()
-    process.executableURL = tool
-    process.arguments = arguments
-
-    var environment = ProcessInfo.processInfo.environment
-    if let sdk {
-      environment.updateValue(sdk.path, forKey: "SDKROOT")
-    } else {
-      environment.removeValue(forKey: "SDKROOT")
-    }
-    environment.removeValue(forKey: "TOOLCHAINS")
-
-    process.environment = environment
-
-    try process.run()
-    process.waitUntilExit()
-    _exit(process.terminationStatus)
-  }
 }


### PR DESCRIPTION
As the tool may be scoped to the SDK, hoist the `execute` method to a standalone utility.