### PR TITLE
tcrun: extract `PlatformCollection`

### DIFF
--- a/Sources/tcrun/Platform.swift
+++ b/Sources/tcrun/Platform.swift
@@ -20,38 +20,3 @@ internal struct Platform {
     SDKs.first { $0.lastPathComponent == name }
   }
 }
-
-internal struct PlatformCollection {
-  public let root: URL
-  public let platforms: [Platform]
-
-  public init(root: URL, platforms: [Platform]) {
-    self.root = root
-    self.platforms = platforms
-  }
-
-  public func containing(sdk: String) -> [Platform] {
-    platforms.filter { $0.contains(sdk: sdk) }
-  }
-}
-
-extension PlatformCollection: Collection {
-  public typealias Element = Platform
-  public typealias Index = Array<Platform>.Index
-
-  public var startIndex: Index {
-    platforms.startIndex
-  }
-
-  public var endIndex: Index {
-    platforms.endIndex
-  }
-
-  public subscript(index: Index) -> Platform {
-    return platforms[index]
-  }
-
-  public func index(after i: Index) -> Index {
-    return platforms.index(after: i)
-  }
-}

--- a/Sources/tcrun/PlatformCollection.swift
+++ b/Sources/tcrun/PlatformCollection.swift
@@ -1,0 +1,39 @@
+// Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import Foundation
+
+internal struct PlatformCollection {
+  public let root: URL
+  public let platforms: [Platform]
+
+  public init(root: URL, platforms: [Platform]) {
+    self.root = root
+    self.platforms = platforms
+  }
+
+  public func containing(sdk: String) -> [Platform] {
+    platforms.filter { $0.contains(sdk: sdk) }
+  }
+}
+
+extension PlatformCollection: Collection {
+  public typealias Element = Platform
+  public typealias Index = Array<Platform>.Index
+
+  public var startIndex: Index {
+    platforms.startIndex
+  }
+
+  public var endIndex: Index {
+    platforms.endIndex
+  }
+
+  public subscript(index: Index) -> Platform {
+    return platforms[index]
+  }
+
+  public func index(after i: Index) -> Index {
+    return platforms.index(after: i)
+  }
+}


### PR DESCRIPTION
This simply separates the two types into separate files for organisational reasons.