### PR TITLE
Various cleanup changes to improve the structure of the code

### DIFF
--- a/Sources/tcrun/Platform.swift
+++ b/Sources/tcrun/Platform.swift
@@ -6,9 +6,9 @@ internal import Foundation
 internal struct Platform {
   public let identifier: String
   public let location: URL
-  public let SDKs: [URL]
+  public let SDKs: [SDK]
 
-  public init(location: URL, SDKs: [URL]) {
+  public init(location: URL, SDKs: [SDK]) {
     self.identifier = location.lastPathComponent
     self.location = location
     self.SDKs = SDKs
@@ -17,10 +17,10 @@ internal struct Platform {
 
 extension Platform {
   public func contains(sdk named: String) -> Bool {
-    SDKs.contains { $0.lastPathComponent == named }
+    SDKs.contains { $0.identifier == named }
   }
 
-  public func sdk(named name: String) -> URL? {
-    SDKs.first { $0.lastPathComponent == name }
+  public func sdk(named name: String) -> SDK? {
+    SDKs.first { $0.identifier == name }
   }
 }

--- a/Sources/tcrun/Platform.swift
+++ b/Sources/tcrun/Platform.swift
@@ -11,7 +11,9 @@ internal struct Platform {
     self.id = id
     self.SDKs = SDKs
   }
+}
 
+extension Platform {
   public func contains(sdk named: String) -> Bool {
     SDKs.contains { $0.lastPathComponent == named }
   }

--- a/Sources/tcrun/Platform.swift
+++ b/Sources/tcrun/Platform.swift
@@ -5,10 +5,12 @@ internal import Foundation
 
 internal struct Platform {
   public let identifier: String
+  public let location: URL
   public let SDKs: [URL]
 
-  public init(id: String, SDKs: [URL]) {
-    self.identifier = id
+  public init(location: URL, SDKs: [URL]) {
+    self.identifier = location.lastPathComponent
+    self.location = location
     self.SDKs = SDKs
   }
 }

--- a/Sources/tcrun/Platform.swift
+++ b/Sources/tcrun/Platform.swift
@@ -4,11 +4,11 @@
 internal import Foundation
 
 internal struct Platform {
-  public let id: String
+  public let identifier: String
   public let SDKs: [URL]
 
   public init(id: String, SDKs: [URL]) {
-    self.id = id
+    self.identifier = id
     self.SDKs = SDKs
   }
 }

--- a/Sources/tcrun/SDK.swift
+++ b/Sources/tcrun/SDK.swift
@@ -1,0 +1,14 @@
+// Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal import Foundation
+
+internal struct SDK {
+  public let identifier: String
+  public let location: URL
+
+  public init(location: URL) {
+    self.identifier = location.lastPathComponent
+    self.location = location
+  }
+}

--- a/Sources/tcrun/SwiftInstallation.swift
+++ b/Sources/tcrun/SwiftInstallation.swift
@@ -171,7 +171,7 @@ extension SwiftInstallation: CustomStringConvertible {
       }
       return (
         [
-          "    - \(platform.id)",
+          "    - \(platform.identifier)",
           "        SDKs:",
         ] + sdks
       ).joined(separator: "\n")

--- a/Sources/tcrun/SwiftInstallation.swift
+++ b/Sources/tcrun/SwiftInstallation.swift
@@ -43,6 +43,8 @@ private func EnumeratePlatforms(in DEVELOPER_DIR: URL, version: Version)
                       try entry.lastPathComponent.hasSuffix(".sdk") &&
                           entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory == true
                     }
+                    .map(SDK.init(location:))
+
             return Platform(location: platform, SDKs: SDKs)
           }
   return PlatformCollection(root: PlatformsVersioned, platforms: platforms)
@@ -135,7 +137,7 @@ extension SwiftInstallation {
 
   internal func contains(sdk identifier: String) -> Bool {
     return platforms.contains { platform in
-      return platform.SDKs.contains { $0.lastPathComponent == identifier }
+      return platform.SDKs.contains { $0.identifier == identifier }
     }
   }
 }
@@ -151,7 +153,7 @@ extension SwiftInstallation {
 extension SwiftInstallation {
   internal func platforms(containing sdk: String) -> [Platform] {
     return self.platforms.filter { platform in
-      return platform.SDKs.contains { $0.lastPathComponent == sdk }
+      return platform.SDKs.contains { $0.identifier == sdk }
     }
   }
 
@@ -167,7 +169,7 @@ extension SwiftInstallation: CustomStringConvertible {
 
     let platforms = self.platforms.map { platform in
       let sdks = platform.SDKs.map { sdk in
-        "          - \(sdk.lastPathComponent) [\(sdk.path)]"
+        "          - \(sdk.identifier) [\(sdk.location.path)]"
       }
       return (
         [

--- a/Sources/tcrun/SwiftInstallation.swift
+++ b/Sources/tcrun/SwiftInstallation.swift
@@ -43,7 +43,7 @@ private func EnumeratePlatforms(in DEVELOPER_DIR: URL, version: Version)
                       try entry.lastPathComponent.hasSuffix(".sdk") &&
                           entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory == true
                     }
-            return Platform(id: platform.lastPathComponent, SDKs: SDKs)
+            return Platform(location: platform, SDKs: SDKs)
           }
   return PlatformCollection(root: PlatformsVersioned, platforms: platforms)
 }

--- a/Sources/tcrun/Utilities.swift
+++ b/Sources/tcrun/Utilities.swift
@@ -4,6 +4,12 @@
 internal import Foundation
 private import WindowsCore
 
+private nonisolated(unsafe) var kPathExtensions =
+    (try? GetEnvironmentVariable("PATHEXT"))?
+        .split(separator: ";")
+        .map(String.init)
+      ?? []
+
 internal func GetEnvironmentVariable(_ name: String) throws -> String? {
   try name.withCString(encodedAs: UTF16.self) { szVariable in
     let dwResult = GetEnvironmentVariableW(szVariable, nil, 0)
@@ -56,7 +62,7 @@ internal func SearchExecutable(_ name: String, in directory: String? = nil)
     return path
   }
 
-  for `extension` in try GetEnvironmentVariable("PATHEXT")?.split(separator: ";") ?? [] {
+  for `extension` in kPathExtensions {
     if let result = try search(name, in: directory, extension: String(`extension`)) {
       return result
     }

--- a/Sources/tcrun/main.swift
+++ b/Sources/tcrun/main.swift
@@ -157,7 +157,7 @@ private struct tcrun: ParsableCommand {
 
     if showSDKPath {
       guard let sdk = platform.sdk(named: sdk) else { return }
-      return print(sdk.path)
+      return print(sdk.location.path)
     }
 
     // Handle tool execution.
@@ -174,7 +174,7 @@ private struct tcrun: ParsableCommand {
 
       case .run:
         try execute(URL(filePath: path), arguments,
-                    sdk: self.sdk.map(platform.sdk(named:)) ?? nil)
+                    sdk: self.sdk.map(platform.sdk(named:))??.location)
       }
     }
   }

--- a/Sources/tcrun/main.swift
+++ b/Sources/tcrun/main.swift
@@ -150,7 +150,7 @@ private struct tcrun: ParsableCommand {
 
     if showSDKPlatformPath {
       let root =
-          installation.platforms.root.appending(component: platform.id,
+          installation.platforms.root.appending(component: platform.identifier,
                                                 directoryHint: .isDirectory)
       return print(root.path)
     }


### PR DESCRIPTION
This pull request refactors the way platforms and SDKs are represented and enumerated in the codebase. The main improvement is the introduction of a dedicated `SDK` struct, which replaces the use of raw `URL` values for SDKs throughout the code. This change leads to clearer, more maintainable code and enables more robust handling of SDK metadata. Additionally, the enumeration logic for platforms, SDKs, and toolchains is updated to use directory enumerators for improved accuracy and extensibility. There are also minor optimizations and cleanups in environment variable handling and command-line output.

**Platform and SDK Refactoring:**

* Introduced a new `SDK` struct in `SDK.swift` to encapsulate SDK metadata, replacing the previous use of `URL` for SDKs. The struct includes `identifier` and `location` properties.
* Updated the `Platform` struct in `Platform.swift` to use the new `SDK` type for its `SDKs` property, and replaced the `id` property with `identifier` and `location`. Methods like `contains(sdk:)` and `sdk(named:)` now operate on `SDK.identifier`.
* Updated all references and uses of SDKs in `SwiftInstallation.swift` and `main.swift` to use the new `SDK` struct, ensuring consistent access to identifiers and locations. [[1]](diffhunk://#diff-d6f2d1eba6810aeaf9aea4df37f132c98949199523ae2e0a45f13b6556da1022L138-R150) [[2]](diffhunk://#diff-d6f2d1eba6810aeaf9aea4df37f132c98949199523ae2e0a45f13b6556da1022L154-R166) [[3]](diffhunk://#diff-d6f2d1eba6810aeaf9aea4df37f132c98949199523ae2e0a45f13b6556da1022L170-R186) [[4]](diffhunk://#diff-fb231fd089e5056521adbc0fba4eb45e1aac8c41da4978c8a4548e163811d1b1L153-R160) [[5]](diffhunk://#diff-fb231fd089e5056521adbc0fba4eb45e1aac8c41da4978c8a4548e163811d1b1L177-R177)

**Enumeration Improvements:**

* Changed platform, SDK, and toolchain enumeration in `SwiftInstallation.swift` to use `FileManager.enumerator` with `.skipsSubdirectoryDescendants` instead of `contentsOfDirectory`, allowing for more flexible and correct traversal of directories. [[1]](diffhunk://#diff-d6f2d1eba6810aeaf9aea4df37f132c98949199523ae2e0a45f13b6556da1022L28-R32) [[2]](diffhunk://#diff-d6f2d1eba6810aeaf9aea4df37f132c98949199523ae2e0a45f13b6556da1022L40-R68) [[3]](diffhunk://#diff-d6f2d1eba6810aeaf9aea4df37f132c98949199523ae2e0a45f13b6556da1022R86-R88)

**Performance and Cleanups:**

* Cached the parsed `PATHEXT` environment variable in a `kPathExtensions` variable to avoid repeated parsing in `Utilities.swift`. [[1]](diffhunk://#diff-1ff36445b773e1741c8629a5646dfa373e7c7b853f4f8809a2705b2824874cdaR7-R12) [[2]](diffhunk://#diff-1ff36445b773e1741c8629a5646dfa373e7c7b853f4f8809a2705b2824874cdaL59-R65)

These changes collectively improve code clarity, maintainability, and performance, especially in how platforms and SDKs are modeled and discovered.