### PR TITLE
PlatformCollection: split out query functions

### DIFF
--- a/Sources/tcrun/PlatformCollection.swift
+++ b/Sources/tcrun/PlatformCollection.swift
@@ -11,7 +11,9 @@ internal struct PlatformCollection {
     self.root = root
     self.platforms = platforms
   }
+}
 
+extension PlatformCollection {
   public func containing(sdk: String) -> [Platform] {
     platforms.filter { $0.contains(sdk: sdk) }
   }


### PR DESCRIPTION
Extract the query methods in `PlatformCollection` from the core type definition.