### PR TITLE
tcrun: move `execute(_:_:sdk:)` into `Utilities.swift`

### DIFF
--- a/Sources/tcrun/Utilities.swift
+++ b/Sources/tcrun/Utilities.swift
@@ -71,3 +71,23 @@ internal func SearchExecutable(_ name: String, in directory: String? = nil)
   return nil
 }
 
+internal func execute(_ tool: URL, _ arguments: [String]? = nil,
+                      sdk: URL? = nil) throws -> Never {
+  let process = Process()
+  process.executableURL = tool
+  process.arguments = arguments
+
+  var environment = ProcessInfo.processInfo.environment
+  if let sdk {
+    environment.updateValue(sdk.path, forKey: "SDKROOT")
+  } else {
+    environment.removeValue(forKey: "SDKROOT")
+  }
+  environment.removeValue(forKey: "TOOLCHAINS")
+
+  process.environment = environment
+
+  try process.run()
+  process.waitUntilExit()
+  _exit(process.terminationStatus)
+}

--- a/Sources/tcrun/main.swift
+++ b/Sources/tcrun/main.swift
@@ -22,27 +22,6 @@ private enum SDKResolver {
   }
 }
 
-internal func execute(_ tool: URL, _ arguments: [String]? = nil,
-                      sdk: URL? = nil) throws -> Never {
-  let process = Process()
-  process.executableURL = tool
-  process.arguments = arguments
-
-  var environment = ProcessInfo.processInfo.environment
-  if let sdk {
-    environment.updateValue(sdk.path, forKey: "SDKROOT")
-  } else {
-    environment.removeValue(forKey: "SDKROOT")
-  }
-  environment.removeValue(forKey: "TOOLCHAINS")
-
-  process.environment = environment
-
-  try process.run()
-  process.waitUntilExit()
-  _exit(process.terminationStatus)
-}
-
 @main
 private struct tcrun: ParsableCommand {
   public static var configuration: CommandConfiguration {


### PR DESCRIPTION
Move the helper into the utilities to simplify the main entry point definition.