### PR TITLE
tcrun: move to delayed iteration (caching iteration)

### DIFF
--- a/Sources/tcrun/MemoizedSequence.swift
+++ b/Sources/tcrun/MemoizedSequence.swift
@@ -1,0 +1,39 @@
+// Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+internal struct MemoizedSequence<Element>: Sequence {
+  private final class Storage {
+    var iterator: AnyIterator<Element>?
+    var cache: [Element] = []
+
+    init<SequenceType: Sequence>(_ sequence: SequenceType) where SequenceType.Element == Element {
+      self.iterator = AnyIterator(sequence.makeIterator())
+    }
+  }
+
+  private var storage: Storage
+
+  internal init<SequenceType: Sequence>(_ sequence: SequenceType) where SequenceType.Element == Element {
+    self.storage = Storage(sequence)
+  }
+
+  internal func makeIterator() -> AnyIterator<Element> {
+    var index = 0
+
+    return AnyIterator<Element> {
+      if index < storage.cache.count {
+        defer { index += 1 }
+        return storage.cache[index]
+      }
+
+      guard let next = storage.iterator?.next() else {
+        storage.iterator = nil
+        return nil
+      }
+
+      storage.cache.append(next)
+      defer { index += 1 }
+      return next
+    }
+  }
+}

--- a/Sources/tcrun/Platform.swift
+++ b/Sources/tcrun/Platform.swift
@@ -6,9 +6,9 @@ internal import Foundation
 internal struct Platform {
   public let identifier: String
   public let location: URL
-  public let SDKs: [SDK]
+  public let SDKs: MemoizedSequence<SDK>
 
-  public init(location: URL, SDKs: [SDK]) {
+  public init(location: URL, SDKs: MemoizedSequence<SDK>) {
     self.identifier = location.lastPathComponent
     self.location = location
     self.SDKs = SDKs

--- a/Sources/tcrun/main.swift
+++ b/Sources/tcrun/main.swift
@@ -128,10 +128,7 @@ private struct tcrun: ParsableCommand {
     }
 
     if showSDKPlatformPath {
-      let root =
-          installation.platforms.root.appending(component: platform.identifier,
-                                                directoryHint: .isDirectory)
-      return print(root.path)
+      return print(platform.location.path)
     }
 
     if showSDKPath {


### PR DESCRIPTION
This allows us to avoid the need for immediately iterating the entire directory tree and enumerating every installation. Instead, we delay the enumeration until we need the specific value (either to search or iterate). The desire is to manage to get to the point where we can avoid the iteration for most of the cases.