### PR TITLE
tcrun: avoid unnecessary boxing overhead, simplify

### DIFF
--- a/Sources/tcrun/Extensions/Foundation+Extensions.swift
+++ b/Sources/tcrun/Extensions/Foundation+Extensions.swift
@@ -7,4 +7,10 @@ extension URL {
   internal var path: String {
     self.withUnsafeFileSystemRepresentation { String(cString: $0!) }
   }
+
+  internal var isDirectory: Bool {
+    get throws {
+      try resourceValues(forKeys: [.isDirectoryKey]).isDirectory == true
+    }
+  }
 }

--- a/Sources/tcrun/Platform.swift
+++ b/Sources/tcrun/Platform.swift
@@ -8,10 +8,10 @@ internal struct Platform {
   public let location: URL
   public let SDKs: MemoizedSequence<SDK>
 
-  public init(location: URL, SDKs: MemoizedSequence<SDK>) {
+  internal init(location: URL, SDKs: SDKEnumerator) {
     self.identifier = location.lastPathComponent
     self.location = location
-    self.SDKs = SDKs
+    self.SDKs = MemoizedSequence(SDKs)
   }
 }
 
@@ -22,5 +22,42 @@ extension Platform {
 
   public func sdk(named identifier: String) -> SDK? {
     return SDKs.first { $0.identifier == identifier }
+  }
+}
+
+extension PlatformEnumerator {
+  internal struct Iterator: IteratorProtocol {
+    private let enumerator: FileManager.DirectoryEnumerator?
+
+    internal init(root: URL) {
+      self.enumerator =
+          FileManager.default.enumerator(at: root,
+                                         includingPropertiesForKeys: [.isDirectoryKey],
+                                         options: [.skipsHiddenFiles])
+    }
+
+    internal mutating func next() -> Platform? {
+      while let location = enumerator?.nextObject() as? URL {
+        guard location.lastPathComponent.hasSuffix(".platform"),
+            (try? location.isDirectory) ?? false else {
+          continue
+        }
+        return Platform(location: location, SDKs: SDKEnumerator(in: location))
+      }
+      return nil
+    }
+  }
+}
+
+internal struct PlatformEnumerator: Sequence {
+  private let root: URL
+
+  internal init(in DEVELOPER_DIR: URL, version: Version) {
+    self.root = DEVELOPER_DIR.appending(components: "Platforms", version.description,
+                                        directoryHint: .isDirectory)
+  }
+
+  internal func makeIterator() -> Iterator {
+    Iterator(root: root)
   }
 }

--- a/Sources/tcrun/Platform.swift
+++ b/Sources/tcrun/Platform.swift
@@ -33,7 +33,7 @@ extension PlatformEnumerator {
       self.enumerator =
           FileManager.default.enumerator(at: root,
                                          includingPropertiesForKeys: [.isDirectoryKey],
-                                         options: [.skipsHiddenFiles])
+                                         options: [.skipsSubdirectoryDescendants])
     }
 
     internal mutating func next() -> Platform? {

--- a/Sources/tcrun/SDK.swift
+++ b/Sources/tcrun/SDK.swift
@@ -12,3 +12,40 @@ internal struct SDK {
     self.location = location
   }
 }
+
+extension SDKEnumerator {
+  internal struct Iterator: IteratorProtocol {
+    private let enumerator: FileManager.DirectoryEnumerator?
+
+    internal init(root: URL) {
+      self.enumerator =
+          FileManager.default.enumerator(at: root,
+                                         includingPropertiesForKeys: [.isDirectoryKey],
+                                         options: [.skipsSubdirectoryDescendants])
+    }
+
+    internal mutating func next() -> SDK? {
+      while let location = enumerator?.nextObject() as? URL {
+        guard location.lastPathComponent.hasSuffix(".sdk"),
+            (try? location.isDirectory) ?? false else{
+          continue
+        }
+        return SDK(location: location)
+      }
+      return nil
+    }
+  }
+}
+
+internal struct SDKEnumerator: Sequence {
+  private let root: URL
+
+  internal init(in platform: URL) {
+    self.root = platform.appending(components: "Developer", "SDKs",
+                                   directoryHint: .isDirectory)
+  }
+
+  internal func makeIterator() -> Iterator {
+    Iterator(root: root)
+  }
+}

--- a/Sources/tcrun/SDK.swift
+++ b/Sources/tcrun/SDK.swift
@@ -27,7 +27,7 @@ extension SDKEnumerator {
     internal mutating func next() -> SDK? {
       while let location = enumerator?.nextObject() as? URL {
         guard location.lastPathComponent.hasSuffix(".sdk"),
-            (try? location.isDirectory) ?? false else{
+            (try? location.isDirectory) ?? false else {
           continue
         }
         return SDK(location: location)

--- a/Sources/tcrun/Toolchain.swift
+++ b/Sources/tcrun/Toolchain.swift
@@ -22,3 +22,52 @@ extension Toolchain {
     try SearchExecutable(tool, in: self.bindir.path)
   }
 }
+
+extension ToolchainEnumerator {
+  internal struct Iterator: IteratorProtocol {
+    private let enumerator: FileManager.DirectoryEnumerator?
+
+    internal init(root: URL) {
+      // FIXME: can we enumerate the toolchains from the installed packages?
+      self.enumerator =
+          FileManager.default.enumerator(at: root,
+                                         includingPropertiesForKeys: [.isDirectoryKey],
+                                         options: [.skipsHiddenFiles])
+    }
+
+    // TODO: how should we sort the toolchains?
+    internal mutating func next() -> Toolchain? {
+      while let location = enumerator?.nextObject() as? URL {
+        guard (try? location.isDirectory) ?? false else {
+          continue
+        }
+
+        let ToolchainInfo = location.appending(component: "ToolchainInfo.plist")
+
+        // FIXME: we should propagate an error if the toolchain image is invalid
+        guard let info =
+            try? PropertyListSerialization.propertyList(from: Data(contentsOf: ToolchainInfo),
+                                                        format: nil) as? Dictionary<String, Any> else {
+          return nil
+        }
+
+        return Toolchain(identifier: info["Identifier"] as? String ?? "",
+                         location: location)
+      }
+      return nil
+    }
+  }
+}
+
+internal struct ToolchainEnumerator: Sequence {
+  private let root: URL
+
+  internal init(in DEVELOPER_DIR: URL) {
+    self.root = DEVELOPER_DIR.appending(components: "Toolchains",
+                                        directoryHint: .isDirectory)
+  }
+
+  internal func makeIterator() -> Iterator {
+    Iterator(root: root)
+  }
+}

--- a/Sources/tcrun/Toolchain.swift
+++ b/Sources/tcrun/Toolchain.swift
@@ -32,7 +32,7 @@ extension ToolchainEnumerator {
       self.enumerator =
           FileManager.default.enumerator(at: root,
                                          includingPropertiesForKeys: [.isDirectoryKey],
-                                         options: [.skipsHiddenFiles])
+                                         options: [.skipsSubdirectoryDescendants])
     }
 
     // TODO: how should we sort the toolchains?


### PR DESCRIPTION
Use explicitly typed iterators for Toolchains, Platforms, and SDKs to avoid unnecessary boxing. Split up the enumerators across multiple files and calls to simplify the structure and code.