### PR TITLE
tcrun: migrate nearly entirely to `FoundationEssentials`

### DIFF
--- a/Sources/tcrun/Extensions/Foundation+Extensions.swift
+++ b/Sources/tcrun/Extensions/Foundation+Extensions.swift
@@ -1,7 +1,7 @@
 // Copyright © 2025 Saleem Abdulrasool
 // SPDX-License-Identifier: BSD-3-Clause
 
-internal import Foundation
+internal import FoundationEssentials
 
 extension URL {
   internal var path: String {

--- a/Sources/tcrun/Extensions/String+Extensions.swift
+++ b/Sources/tcrun/Extensions/String+Extensions.swift
@@ -1,7 +1,7 @@
 // Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-internal import Foundation
+internal import FoundationEssentials
 
 extension Optional where Wrapped == String {
   internal func withUTF16CString<T>(_ body: (UnsafePointer<UTF16.CodeUnit>?) throws -> T)

--- a/Sources/tcrun/Extensions/WinSDK+ManagedHandle.swift
+++ b/Sources/tcrun/Extensions/WinSDK+ManagedHandle.swift
@@ -1,7 +1,7 @@
 // Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-internal import Foundation
+internal import FoundationEssentials
 internal import WindowsCore
 
 extension HKEY: HandleValue {

--- a/Sources/tcrun/Platform.swift
+++ b/Sources/tcrun/Platform.swift
@@ -1,7 +1,7 @@
 // Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-internal import Foundation
+internal import FoundationEssentials
 
 internal struct Platform {
   public let identifier: String

--- a/Sources/tcrun/SDK.swift
+++ b/Sources/tcrun/SDK.swift
@@ -1,7 +1,7 @@
 // Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-internal import Foundation
+internal import FoundationEssentials
 
 internal struct SDK {
   public let identifier: String

--- a/Sources/tcrun/SwiftInstallation.swift
+++ b/Sources/tcrun/SwiftInstallation.swift
@@ -1,7 +1,7 @@
 // Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-internal import Foundation
+internal import FoundationEssentials
 internal import WindowsCore
 
 private nonisolated(unsafe) let kRegistryPaths = [

--- a/Sources/tcrun/Toolchain.swift
+++ b/Sources/tcrun/Toolchain.swift
@@ -1,7 +1,7 @@
 // Copyright © 2025 Saleem Abdulrasool <compnerd@compnerd.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-internal import Foundation
+internal import FoundationEssentials
 
 internal struct Toolchain {
   public let identifier: String
@@ -23,6 +23,12 @@ extension Toolchain {
   }
 }
 
+internal struct ToolchainInfo: Decodable {
+  let Identifier: String
+  let Version: String
+  let FallbackLibrarySearchPaths: [String]?
+}
+
 extension ToolchainEnumerator {
   internal struct Iterator: IteratorProtocol {
     private let enumerator: FileManager.DirectoryEnumerator?
@@ -42,17 +48,14 @@ extension ToolchainEnumerator {
           continue
         }
 
-        let ToolchainInfo = location.appending(component: "ToolchainInfo.plist")
-
         // FIXME: we should propagate an error if the toolchain image is invalid
         guard let info =
-            try? PropertyListSerialization.propertyList(from: Data(contentsOf: ToolchainInfo),
-                                                        format: nil) as? Dictionary<String, Any> else {
+            try? PropertyListDecoder().decode(ToolchainInfo.self,
+                                              from: Data(contentsOf: location.appending(component: "ToolchainInfo.plist"))) else {
           return nil
         }
 
-        return Toolchain(identifier: info["Identifier"] as? String ?? "",
-                         location: location)
+        return Toolchain(identifier: info.Identifier, location: location)
       }
       return nil
     }

--- a/Sources/tcrun/main.swift
+++ b/Sources/tcrun/main.swift
@@ -4,7 +4,7 @@
 private import ArgumentParser
 private import WindowsCore
 
-internal import Foundation
+internal import FoundationEssentials
 
 extension SDK {
   fileprivate static func identifier(for invocation: borrowing tcrun) throws -> String {


### PR DESCRIPTION
`FoundationEssentials` does not provide `Process`. Migrating to `subprocess` would allow us to fully migrate to `FoundationEssentials` allowing us to trim ICU.