### PR TITLE
tcrun: mark additional field in `ToolchainInfo.plist` as optional

### DIFF
--- a/Sources/tcrun/Toolchain.swift
+++ b/Sources/tcrun/Toolchain.swift
@@ -25,7 +25,7 @@ extension Toolchain {
 
 internal struct ToolchainInfo: Decodable {
   let Identifier: String
-  let Version: String
+  let Version: String?
   let FallbackLibrarySearchPaths: [String]?
 }
 


### PR DESCRIPTION
Mark `version` as optional to mirror reality. The identifier was the original field that was present and thus is guaranteed to be there.