### PR TITLE
tcrun: replace `Foundation` with `Subprocess`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,12 +12,15 @@ let _ =
                        from: "1.5.0"),
               .package(url: "https://github.com/compnerd/swift-platform-core",
                        branch: "main"),
+              .package(url: "https://github.com/swiftlang/swift-subprocess.git",
+                       branch: "main"),
             ],
             targets: [
               .executableTarget(name: "tcrun",
                                 dependencies: [
                                   .product(name: "ArgumentParser", package: "swift-argument-parser"),
                                   .product(name: "WindowsCore", package: "swift-platform-core"),
+                                  .product(name: "Subprocess", package: "swift-subprocess"),
                                 ],
                                 swiftSettings: [
                                   .enableExperimentalFeature("AccessLevelOnImport"),

--- a/Sources/tcrun/main.swift
+++ b/Sources/tcrun/main.swift
@@ -33,7 +33,7 @@ extension Toolchain {
 }
 
 @main
-private struct tcrun: ParsableCommand {
+private struct tcrun: AsyncParsableCommand {
   public static var configuration: CommandConfiguration {
     CommandConfiguration(abstract: "Swift Toolchain Execution Helper")
   }
@@ -106,7 +106,7 @@ private struct tcrun: ParsableCommand {
     }
   }
 
-  public mutating func run() throws {
+  public mutating func run() async throws {
     if version {
       return print("tcrun \(PackageVersion)")
     }
@@ -158,8 +158,8 @@ private struct tcrun: ParsableCommand {
         print(path)
 
       case .run:
-        try execute(URL(filePath: path), arguments,
-                    sdk: self.sdk.map(platform.sdk(named:))??.location)
+        try await execute(URL(filePath: path), arguments,
+                          sdk: self.sdk.map(platform.sdk(named:))??.location)
       }
     }
   }


### PR DESCRIPTION
Remove the last of the use of `Foundation`, allowing migration to `FoundationEssentials`. Adopt `Subprocess` as `Process` is part of `Foundation` and not available in `FoundationEssentials`.